### PR TITLE
Format number sequence and watermark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+output/
+stamp/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Second Story Toolkit Scripts
+
+Scripts in this repository have been created to assist with compiling new teaching materials.
+
+## Image Generation
+
+This script will add a sequential number to each image, as well as a watermark for Second Story Toolkit.
+
+### Prerequistes
+
+1. `imagemagick` command line tool
+2. Roboto family of fonts (Roboto-Bold and Roboto-Bold-Italic) installed on system
+
+### Usage
+
+1. List full paths of the images to watermark and number them in `home-safety-problems-images.txt`.
+2. Run script from terminal with `$ sh generate-images.sh` (from within hame-safety-problem-images directory).
+3. View watermarked and numbered images in the `output` directory.

--- a/generate-images.sh
+++ b/generate-images.sh
@@ -7,32 +7,35 @@ OUTPUT=output
 WATERMARK='© 2nd Story Toolkit'
 
 stamp() {
-  # generate watermark 
+  # generate watermark
+  # see https://amytabb.com/til/photography/2021/01/23/image-magick-watermark/ for reference
   mkdir -p stamp
   pushd stamp || return
-  convert -size 600x100 xc:grey30 -font Arial -pointsize 40 -gravity center \
-    -draw "fill grey70  text 0,0  '$WATERMARK'" \
+  convert -size 1800x300 xc:transparent -font "Roboto-Bold-Italic" -pointsize 100 -gravity center \
+      -fill black        -annotate +24+64 "$WATERMARK" \
+      -fill white        -annotate +26+66 "$WATERMARK" \
+      -fill transparent  -annotate +25+65 "$WATERMARK" \
     stamp_fgnd.png
-  convert -size 600x100 xc:black -font Arial -pointsize 40 -gravity center \
-    -draw "fill white  text  1,1  '$WATERMARK'  \
-                                text  0,0  '$WATERMARK'  \
-                    fill black  text -1,-1 '$WATERMARK'" \
-    +matte stamp_mask.png
-  composite -compose CopyOpacity stamp_mask.png stamp_fgnd.png stamp.png
+  convert -size 1800x300 xc:black -font "Roboto-Bold-Italic" -pointsize 100 -gravity center \
+      -fill white   -annotate +24+64 "$WATERMARK" \
+      -fill white   -annotate +26+66 "$WATERMARK" \
+      -fill black   -annotate +25+65 "$WATERMARK" \
+    stamp_mask.jpg
+  composite -compose CopyOpacity stamp_mask.jpg stamp_fgnd.png stamp.png
   mogrify -trim +repage stamp.png
   popd || return
 }
 
 watermark() {
   filename=$1
-  composite -gravity southeast -geometry +0+10 stamp/stamp.png  "$filename" "$filename"
+  composite -gravity southeast -geometry +40+30 stamp/stamp.png  "$filename" "$filename"
 }
 
 number() {
   filename=$1
   number=$2
   output="$OUTPUT"/"$number".jpeg
-  convert "$filename" -gravity SouthWest -pointsize 250 -fill black -annotate 0 "$number" "$output"
+  convert "$filename" -resize 3400x2550 -gravity SouthWest -pointsize 100 -fill black -font "Roboto-Bold" -annotate +40+30 "$number" "$output"
   echo "$output"
 }
 


### PR DESCRIPTION
Updated watermark to be transparent, adjusted sizing and changed font to Roboto.

See example of number sequence and watermark below.
![example after 1200x900](https://user-images.githubusercontent.com/4926965/217676521-17884992-b4a2-40f5-83d3-4282f8b30611.jpeg)
