### PR TITLE
Configure size and separate number logic

### DIFF
--- a/generate-images.sh
+++ b/generate-images.sh
@@ -31,25 +31,39 @@ resize() {
   filename=$1
   number=$2
   output="$OUTPUT"/"$number".jpeg
-  convert "$filename" -resize "$SIZE" "$output"
+  convert "$filename" \
+      -resize "$SIZE" \
+    "$output"
   echo "$output"
 }
 
 watermark() {
   filename=$1
-  composite -gravity southeast -geometry +40+30 stamp/stamp.png  "$filename" "$filename"
+  composite \
+      -gravity southeast \
+      -geometry +40+30 stamp/stamp.png "$filename" \
+    "$filename"
 }
 
 number() {
   filename=$1
   number=$2
-  convert "$filename" -font "Roboto-Bold" -pointsize 100 -gravity SouthWest \
-      -fill black -annotate +40+30 "$number" "$output"
+  convert "$filename" \
+      -font "Roboto-Bold" \
+      -pointsize 100 \
+      -gravity SouthWest \
+      -fill black -annotate +40+30 "$number" \
+    "$filename"
 }
 
 border() {
   filename=$1
-  convert "$filename" -bordercolor '#FFFFFF' -border 20 -bordercolor '#000000' -border 10 "$filename"
+  convert "$filename" \
+      -bordercolor '#FFFFFF' \
+      -border 20 \
+      -bordercolor '#000000' \
+      -border 10 \
+    "$filename"
 }
 
 # generate stamp file

--- a/generate-images.sh
+++ b/generate-images.sh
@@ -5,6 +5,7 @@ set -o errexit
 IMAGES=home-safety-problems-images.txt
 OUTPUT=output
 WATERMARK='© 2nd Story Toolkit'
+SIZE='2550x2550'  # '3400x2550'
 
 stamp() {
   # generate watermark
@@ -26,6 +27,14 @@ stamp() {
   popd || return
 }
 
+resize() {
+  filename=$1
+  number=$2
+  output="$OUTPUT"/"$number".jpeg
+  convert "$filename" -resize "$SIZE" "$output"
+  echo "$output"
+}
+
 watermark() {
   filename=$1
   composite -gravity southeast -geometry +40+30 stamp/stamp.png  "$filename" "$filename"
@@ -34,10 +43,8 @@ watermark() {
 number() {
   filename=$1
   number=$2
-  output="$OUTPUT"/"$number".jpeg
-  convert "$filename" -resize 3400x2550 -font "Roboto-Bold" -pointsize 100 -gravity SouthWest \
+  convert "$filename" -font "Roboto-Bold" -pointsize 100 -gravity SouthWest \
       -fill black -annotate +40+30 "$number" "$output"
-  echo "$output"
 }
 
 border() {
@@ -54,7 +61,8 @@ while IFS= read -r line; do
   : $((counter = counter + 1))
   echo $counter
   # file "$line"
-  output=$(number "$line" "$counter")
+  output=$(resize "$line" "$counter")
+  number "$output" "$counter"
   watermark "$output"
   border "$output"
 done <$IMAGES


### PR DESCRIPTION
`number` method call can be commented out to not add a number to each image.

https://github.com/kristenmazza/second-story-toolkit-scripts/blob/d4b0724eed33b11ecb3ec06e67d19f313fc4d758/generate-images.sh#L79

Also adds resizing size option to support square images.

![4](https://user-images.githubusercontent.com/4926965/218589448-ef76d548-6e2c-46d7-ab60-90a9ef720465.jpeg)
